### PR TITLE
Parse titles containing attributes

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -101,7 +101,10 @@ func (p *Parser) ParseHTML(buffer io.ReadCloser) error {
 			if atom.Lookup(name) == atom.Body {
 				return nil
 			}
-			if hasAttr {
+			if atom.Lookup(name) == atom.Title {
+				// Toggle title parsing
+				extractTitle = !extractTitle
+			} else if hasAttr {
 				attrs := getAttributes(z)
 				if atom.Lookup(name) == atom.Meta {
 					// Parse HTML meta tag
@@ -119,9 +122,6 @@ func (p *Parser) ParseHTML(buffer io.ReadCloser) error {
 				} else {
 					continue
 				}
-			} else if atom.Lookup(name) == atom.Title {
-				// Toggle title parsing
-				extractTitle = !extractTitle
 			} else {
 				continue
 			}

--- a/parser_test.go
+++ b/parser_test.go
@@ -131,6 +131,17 @@ const html = `
 </body>
 `
 
+const titleHtml = `
+<!doctype html>
+<html class="no-js" lang="">
+
+<head>
+	<title id="pageTitle">Go Meta Parser</title>
+</head>
+<body>
+</body>
+`
+
 func TestParserParseHTML(t *testing.T) {
 	p := parser.New()
 	err := p.ParseHTML(ioutil.NopCloser(strings.NewReader(html)))
@@ -535,6 +546,18 @@ func TestParserParseHTMLWithResult(t *testing.T) {
 
 	if result.GetDescription() != result.OpenGraph.Description {
 		t.Error("GetDescription does not return correct description")
+	}
+}
+
+func TestParserParseTitleWithAttribute(t *testing.T) {
+	p := parser.New()
+	result, err := p.ParseHTMLWithResult(ioutil.NopCloser(strings.NewReader(titleHtml)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.GetTitle() != "Go Meta Parser" {
+		t.Error("GetTitle does not return correct title")
 	}
 }
 


### PR DESCRIPTION
Fixes title parsing if the title contains an attribute.

That is a problem on sites like facebook, because the title tag contains a _id_ attribute:
`<title id="pageTitle">`

